### PR TITLE
add npci=0x3000 to bootflags

### DIFF
--- a/CLOVER/config.plist
+++ b/CLOVER/config.plist
@@ -474,7 +474,7 @@
 		<key>#DefaultVolume</key>
 		<string>LastBootedVolume</string>
 		<key>Arguments</key>
-		<string>dart=0 alcid=15</string>
+		<string>dart=0 alcid=15 npci=0x3000</string>
 		<key>DefaultVolume</key>
 		<string>LastBootedVolume</string>
 		<key>Legacy</key>


### PR DESCRIPTION
i was unable to boot without this boot flag on my e580. i cant speak for everyone but i doubt having this in here will hurt anybody. without this flag in here i would get a kernel panic when trying to boot.